### PR TITLE
Add -y option to rosdep install in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ WORKDIR /get-started-ros2
 
 RUN apt-get update \
   && rosdep update \
-  && rosdep install --ignore-src --from-paths src \
+  && rosdep install --ignore-src --from-paths -y src \
   && rm -rf /var/lib/apt/lists/*
 
 RUN source /opt/ros/jazzy/setup.bash \


### PR DESCRIPTION
I sincerely appreciate your publication on ROS 2.
It has been very helpful and a great reference.

### Summary

Add the -y option to the rosdep install command in the Dockerfile to make the installation non-interactive.

### Motivation

Without the -y flag, rosdep install may prompt for confirmation during the image build

### Example Error Log (Before the Fix)
```
20.35 After this operation, 1271 MB of additional disk space will be used.
20.35 Do you want to continue? [Y/n] Abort.
20.35 ERROR: the following rosdeps failed to install
20.35   apt: command [apt-get install libopencv-dev] failed
20.35 executing command [apt-get install ros-jazzy-example-interfaces]
20.35 executing command [apt-get install ros-jazzy-action-tutorials-interfaces]
20.35 executing command [apt-get install libopencv-dev]
------
Dockerfile:13
--------------------
  12 |
  13 | >>> RUN apt-get update \
  14 | >>>   && rosdep update \
  15 | >>>   && rosdep install --ignore-src --from-paths src \
  16 | >>>   && rm -rf /var/lib/apt/lists/*
  17 |
--------------------
ERROR: failed to solve: process "/bin/bash -o pipefail -c apt-get update   && rosdep update   && rosdep install --ignore-src --from-paths src   && rm -rf /var/lib/apt/lists/*" did not complete successfully: exit code:
```

### Changes
Modified the rosdep install line in the Dockerfile to include the -y option